### PR TITLE
NGC-939: Return a 400 Bad Request when the OS sent in a version check POST is not recognised

### DIFF
--- a/app/uk/gov/hmrc/yourtaxcalculator/controllers/ErrorHandling.scala
+++ b/app/uk/gov/hmrc/yourtaxcalculator/controllers/ErrorHandling.scala
@@ -18,10 +18,10 @@ package uk.gov.hmrc.yourtaxcalculator.controllers
 
 import play.api.{Logger, mvc}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
-import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.http.{BadRequestException, HeaderCarrier, Upstream4xxResponse}
+
 import scala.concurrent.Future
 
-class BadRequestException(message:String) extends uk.gov.hmrc.play.http.HttpException(message, 400)
 class TaxCalculatorConfigException(message: String) extends uk.gov.hmrc.play.http.HttpException(message, 500)
 
 trait ErrorHandling {
@@ -32,8 +32,11 @@ trait ErrorHandling {
 
   def errorWrapper(func: => Future[mvc.Result])(implicit hc: HeaderCarrier) = {
     func.recover {
-      case ex:BadRequestException =>
-        log("BadRequest!")
+      case e:BadRequestException =>
+        log("BadRequest")
+        BadRequest
+      case e:Upstream4xxResponse =>
+        log("UpstreamBadRequest")
         BadRequest
       case ex: TaxCalculatorConfigException =>
         Logger.error(s"TaxCalculatorConfigException : ${ex.getMessage}", ex)

--- a/test/controllers/VersionCheckControllerSpec.scala
+++ b/test/controllers/VersionCheckControllerSpec.scala
@@ -46,7 +46,13 @@ class VersionCheckControllerSpec extends UnitSpec with WithFakeApplication with 
       contentAsJson(result) shouldBe Json.parse("""{"upgradeRequired":true}""")
     }
 
-    "return an error given problem processing the request" in new VersionCheckControllerProblem {
+    "return a BadRequest given problem processing a bad request" in new VersionCheckBadRequest {
+      val result = await(controller.preFlightCheck(None)(deviceRequest))
+
+      status(result) shouldBe 400
+    }
+
+    "return an InternalServerError given problem processing the request" in new VersionCheckControllerProblem {
       val result = await(controller.preFlightCheck(None)(deviceRequest))
 
       status(result) shouldBe 500


### PR DESCRIPTION
Ensure upstream version-check issues are passed down to the api client