### PR TITLE
Add pull and extract paye-estimator.js to sbt Task:decompressTgz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ test-result
 tmp
 .idea_modules
 bin
+
+**/javascripts/**/paye-estimator.js

--- a/decompressTgz.sbt
+++ b/decompressTgz.sbt
@@ -1,0 +1,43 @@
+import java.nio.file.{Files, StandardCopyOption}
+
+val artefactName = "paye-estimator"
+val artefactVersion = "1.3.0"
+
+
+val artefactRepositoryName = s"${artefactName}_sjs0.6_2.11-$artefactVersion"
+val tgz = s"$artefactRepositoryName.tgz"
+val tgzUrl = s"https://dl.bintray.com/hmrc/releases/uk/gov/hmrc/${artefactName}_sjs0.6_2.11/$artefactVersion/$tgz"
+
+libraryDependencies ++= Seq("uk.gov.hmrc" % artefactName % artefactVersion from tgzUrl,
+  "org.apache.commons" % "commons-compress" % "1.13" % "provided")
+
+lazy val decompressTgz = taskKey[Unit]("Decompress TGZ artefact and write output to configured dir")
+
+decompressTgz := {
+  implicit val log = streams.value.log
+
+  lazy val root = Keys.baseDirectory.value
+
+  def finalDestinationDirectory(childDir: Option[String] = None, destRoot : File = root / "public" / "javascripts") = childDir match {
+    case Some(dir) =>  destRoot / dir
+    case _ => destRoot
+  }
+
+  val versionedArtefactName = s"$artefactName-$artefactVersion"
+  val tgzFile = root / "lib_managed" / "tgzs" / "uk.gov.hmrc" / s"$artefactName" / s"$versionedArtefactName.tgz"
+  val extractedTo = Keys.target.value / "extracted" / artefactVersion
+
+  val destination = finalDestinationDirectory(Some(artefactVersion))
+  if (java.nio.file.Files.notExists(destination.toPath)) {
+    log.debug(s"Tar '$tgzFile' will be extracted to ${extractedTo.toPath}")
+
+    Tar.untar(tgzFile, extractedTo)
+    Files.move(extractedTo.toPath, destination.toPath, StandardCopyOption.ATOMIC_MOVE)
+  } else {
+    log.debug(s"Tar '$tgzFile' exists, no need to download.")
+  }
+
+}
+
+// removing this binding until we resolve the backwards compatibility issues
+//compile in Compile <<= (compile in Compile).dependsOn(decompressTgz)

--- a/project/Tar.scala
+++ b/project/Tar.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+object Tar {
+
+  import java.io.{File, FileInputStream, FileOutputStream, OutputStream}
+  import java.util.zip.GZIPInputStream
+  import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+  import scala.annotation.tailrec
+
+  private val BufferSize = 2048
+
+  def untar(tarFile: File, destinationDirectory: File)(implicit log : sbt.Logger): Unit ={
+    destinationDirectory.mkdirs()
+    extract(new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(tarFile))), destinationDirectory)
+  }
+
+  @tailrec
+  def extract(tarInputStream: TarArchiveInputStream, destinationDirectory: File)(implicit log : sbt.Logger): Unit = {
+    Option(tarInputStream.getNextTarEntry) match {
+
+      case Some(entry) if entry.isDirectory =>
+        log.debug("The tar entry was a directory")
+        new File(destinationDirectory, entry.getName).mkdirs()
+        extract(tarInputStream, destinationDirectory)
+
+      case Some(entry) =>
+        log.debug("Extracting the tar entry file")
+        val destinationFile = new File(destinationDirectory, entry.getName)
+        destinationFile.getParentFile.mkdirs()
+        val output = new FileOutputStream(destinationFile)
+        try {
+          pipe(new Array[Byte](BufferSize), tarInputStream, output)
+        } finally {
+          Option(output).map { os =>
+            try {
+              os.close
+            } catch {
+              case t : Throwable =>
+                log.debug("Failed to close the the untar output stream")
+            }
+          }
+        }
+        extract(tarInputStream, destinationDirectory)
+
+      case _ =>
+        log.debug("No more entries in the tar")
+    }
+  }
+
+  @tailrec
+  def pipe(buffer: Array[Byte], tarInputStream: TarArchiveInputStream, entryOutputStream: OutputStream, length: Int = 0)(implicit log : sbt.Logger): Unit = {
+    tarInputStream.read(buffer, 0, BufferSize) match {
+      case len if len != -1 =>
+        entryOutputStream.write(buffer, 0, len)
+        pipe(buffer, tarInputStream, entryOutputStream, len)
+      case _ =>
+        log.debug("Finished piping data into output stream")
+    }
+  }
+
+}


### PR DESCRIPTION
This currently is not attached to the Compile lifecycle but will be added back in once the backwards compatibility issue has been overcome