### PR TITLE
Add build task for sass files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ app/assets/config.codekit3
 app/assets/renewal_poc.html.html
 
 **/javascripts/**/paye-estimator.js
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "your-tax-calculator-frontend",
+  "version": "1.0.0",
+  "description": "[![Build Status](https://travis-ci.org/hmrc/your-tax-calculator-frontend.svg)](https://travis-ci.org/hmrc/your-tax-calculator-frontend) [ ![Download](https://api.bintray.com/packages/hmrc/releases/your-tax-calculator-frontend/images/download.svg) ](https://bintray.com/hmrc/releases/your-tax-calculator-frontend/_latestVersion)",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "test": "test"
+  },
+  "scripts": {
+    "styles": "node project/build-styles.js",
+    "start": "chokidar 'app/assets/**/*.scss' -c 'npm run styles'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hmrc/your-tax-calculator-frontend.git"
+  },
+  "keywords": [],
+  "author": "Rory Powis <rory.powis@digital.hmrc.gov.uk>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/hmrc/your-tax-calculator-frontend/issues"
+  },
+  "homepage": "https://github.com/hmrc/your-tax-calculator-frontend#readme",
+  "devDependencies": {
+    "chokidar-cli": "^1.2.0",
+    "fs-extra": "^2.1.2",
+    "glob": "^7.1.1",
+    "node-sass": "^4.5.2"
+  }
+}

--- a/project/build-styles.js
+++ b/project/build-styles.js
@@ -1,0 +1,48 @@
+var fs = require('fs-extra')
+var path = require('path')
+var glob = require('glob')
+var sass = require('node-sass')
+
+var config = {
+ src: 'app/assets/styles/scss/**/!(_)*.scss',
+ dest: 'app/views/tags'
+}
+
+var writeFile = function (filepath, content) {
+  fs.access(filepath, function (err) {
+    if(err) {
+      fs.mkdirpSync(path.dirname(err.path))
+    }
+
+    fs.writeFile(filepath, content, function (err) {
+      if(err) {
+        return console.log(err)
+      }
+
+      var fileName = path.basename(filepath)
+      console.log('[SUCCESS] ' + fileName)
+    })
+  })
+}
+
+glob(config.src, function (err, files) {
+  console.log('Compiling styles...')
+
+  if(err) {
+    return console.log(err)
+  }
+
+  files.forEach(function (file) {
+    sass.render({
+      file,
+      includePaths: config.includePaths
+    }, function (err, result) {
+      if (err) {
+        return console.log(err);
+      }
+
+      const fileName = path.basename(file, '.scss').split('-')[0]
+      writeFile(config.dest + '/styles_' + fileName + '.scala.html', result.css)
+    })
+  })
+})


### PR DESCRIPTION
Remove the repetitive manual step of compiling the sass.

Just run `npm install` and then `npm start` in the root of the repo to watch for changes in sass files and compile them to css.

This could also be integrated with `sbt` so only one process needs to be run.