### PR TITLE
NGC-1790 Added expandable copy for employed income page.

### DIFF
--- a/app/views/tags/jsCommon.scala.html
+++ b/app/views/tags/jsCommon.scala.html
@@ -31,7 +31,7 @@
               }
           }
           // TODO...report failure to native app!!! Include GA alert!
-          alert("FAILED TO FIND ID ["+id+"]!!!");
+          alert("FAILED TO FIND ID [" + id + "]!!!");
       }
 
       function getAnswerForQuestion(questionId) {
@@ -67,6 +67,26 @@
           }
 
           return modelIds.map(getMapIntValue).reduce(accumulate);
+      }
+
+      function replaceCommonVariablesInElement(element) {
+          // Update the question headers with position info and dates.
+          var endDate = map.get("endDate");
+          var startDate = map.get("startDate");
+          var endDate_PY_1 = map.get("endDate_PY_1");
+          var startDate_PY_1 = map.get("startDate_PY_1");
+
+          var all = element.getElementsByTagName('*');
+
+          for (var i = -1, l = all.length; ++i < l;) {
+              var newText = all[i].innerHTML
+                      .replace("[DATE_A]", startDate)
+                      .replace("[DATE_B]", endDate)
+                      .replace("[DATE_A_PY_1]", startDate_PY_1)
+                      .replace("[DATE_B_PY_1]", endDate_PY_1);
+
+              all[i].innerHTML = newText;
+          }
       }
 
 </script>

--- a/app/views/tags/jsQuestion.scala.html
+++ b/app/views/tags/jsQuestion.scala.html
@@ -68,7 +68,7 @@
     }
 
     function initQuestion(question, control, header) {
-        var questionOutput = question.question
+        var questionOutput = question.question;
 
         // If previousQuestionOption defined then the question text is appended with the question multi-option name of the associated question.
         if (question.previousQuestionOption) {
@@ -167,6 +167,7 @@
             initQuestion(question, 'Continue', 'headerContinue');
             insertDynamicHeader(question, "dynamicHeader-Continue-header", "dynamicHeader-Continue-footer");
 
+            replaceCommonVariablesInElement(document.getElementById('Continue'));
         } else if (question.questionType.type == "Boolean") {
             initQuestion(question, 'Boolean', 'headerBoolean');
             insertDynamicHeader(question, "dynamicHeader-Boolean-header" ,"dynamicHeader-Boolean-footer");
@@ -187,21 +188,20 @@
             }
 
             booleanPageValidation();
-
+            replaceCommonVariablesInElement(document.getElementById('Boolean'));
         } else if (question.questionType.type == "MultipleChoice") {
 
             initQuestion(question, 'MultipleChoice', 'headerMultipleChoice');
             dynamicRadioButton("radio");
             multipleChoicePageValidation();
-
+            replaceCommonVariablesInElement(document.getElementById('MultipleChoice'));
         } else if (question.questionType.type == "MultipleChoiceWithNumber") {
 
             initQuestion(question, 'MultipleChoice', 'headerMultipleChoice');
             dynamicRadioButton("checkbox");
             multipleChoiceWithNumberPageValidation();
-
+            replaceCommonVariablesInElement(document.getElementById('MultipleChoice'));
         } else if (question.questionType.type == "Decimal") {
-
             initQuestion(question, 'Decimal', 'headerDecimal');
             insertDynamicHeader(question, "dynamicHeader-Decimal-header", "dynamicHeader-Decimal-footer");
 
@@ -211,11 +211,13 @@
             if (decimalStore === undefined) {
                 // Clear any previous entry in the field.
                 document.getElementById('DecimalInput').value = ""
-            } else if (decimalStore != "") {
+            } else if (decimalStore !== "") {
                 document.getElementById('DecimalInput').value = decimalStore;
             }
 
             decimalPageValidation();
+
+            replaceCommonVariablesInElement(document.getElementById('Decimal'));
         } else if (question.questionType.type == 'Summary'){
             initSummary();
         }

--- a/app/views/tags/jsQuestionHeaders.scala.html
+++ b/app/views/tags/jsQuestionHeaders.scala.html
@@ -9,8 +9,8 @@
         headerData.set("benefits-and-income", 1);
         headerData.set("household-income", 2);
 
-        introMap.set(replaceStringKeysWithValues("Your income and benefits between [DATE_A] and [DATE_B]", posY), 1);
-        introMap.set(replaceStringKeysWithValues("Other household income, such as income from property between [DATE_A] and [DATE_B]", posY), 2);
+        introMap.set("Your income and benefits between [DATE_A] and [DATE_B]", 1);
+        introMap.set("Other household income, such as income from property between [DATE_A] and [DATE_B]", 2);
         introMap.set("Report any changes to circumstances", 3);
 
         updateHeaders(posY, headerData, introMap);
@@ -26,10 +26,10 @@
         headerData.set("partner", 2);
         headerData.set("household-income", 3);
 
-        introMap.set(replaceStringKeysWithValues("Your income and benefits between [DATE_A] and [DATE_B]", posY), 1);
-        introMap.set(replaceStringKeysWithValues("Your partner’s income and benefits between [DATE_A] and [DATE_B]",posY), 2);
-        introMap.set(replaceStringKeysWithValues("Other household income, such as income from property between [DATE_A] and [DATE_B]", posY), 3);
-        introMap.set(replaceStringKeysWithValues("Report any changes to circumstances", posY), 4);
+        introMap.set("Your income and benefits between [DATE_A] and [DATE_B]", 1);
+        introMap.set("Your partner’s income and benefits between [DATE_A] and [DATE_B]", 2);
+        introMap.set("Other household income, such as income from property between [DATE_A] and [DATE_B]", 3);
+        introMap.set("Report any changes to circumstances", 4);
 
         updateHeaders(posY, headerData, introMap);
     }
@@ -45,12 +45,12 @@
         headerData.set("benefits-and-income", 3);
         headerData.set("household-income", 4);
 
-        introMap.set(replaceStringKeysWithValues("Your income and benefits between [DATE_A_PY_1] and [DATE_B_PY_1]", posY), 1);
-        introMap.set(replaceStringKeysWithValues("Other household income, such as income from property between [DATE_A_PY_1] and [DATE_B_PY_1]", posY), 2);
+        introMap.set("Your income and benefits between [DATE_A_PY_1] and [DATE_B_PY_1]", 1);
+        introMap.set("Other household income, such as income from property between [DATE_A_PY_1] and [DATE_B_PY_1]", 2);
         // MULTI OR SINGLE! true/false
-        introMap.set(replaceStringKeysWithValues("Your income and benefits between [DATE_A] and [DATE_B]", posY), 3);
-        introMap.set(replaceStringKeysWithValues("Other household income, such as income from property between [DATE_A] and [DATE_B]", posY), 4);
-        introMap.set(replaceStringKeysWithValues("Report any changes to circumstances", posY), 5);
+        introMap.set("Your income and benefits between [DATE_A] and [DATE_B]", 3);
+        introMap.set("Other household income, such as income from property between [DATE_A] and [DATE_B]", 4);
+        introMap.set("Report any changes to circumstances", 5);
 
         updateHeaders(posY, headerData, introMap);
     }
@@ -67,30 +67,29 @@
         headerData.set("partner", 5);
         headerData.set("household-income", 6);
 
-        introMap.set(replaceStringKeysWithValues("Your income and benefits between [DATE_A_PY_1] and [DATE_B_PY_1]", posY),1);
-        introMap.set(replaceStringKeysWithValues("Your partner’s income and benefits between [DATE_A_PY_1] and [DATE_B_PY_1]", posY),2);
-        introMap.set(replaceStringKeysWithValues("Other household income, such as income from property between [DATE_A_PY_1] and [DATE_B_PY_1]", posY),3);
-        introMap.set(replaceStringKeysWithValues("Your income and benefits between [DATE_A] and [DATE_B]",posY),4);
-        introMap.set(replaceStringKeysWithValues("Your partner’s income and benefits between [DATE_A] and [DATE_B]",posY),5);
-        introMap.set(replaceStringKeysWithValues("Other household income, such as income from property between [DATE_A] and [DATE_B]",posY),6);
+        introMap.set("Your income and benefits between [DATE_A_PY_1] and [DATE_B_PY_1]",1);
+        introMap.set("Your partner’s income and benefits between [DATE_A_PY_1] and [DATE_B_PY_1]",2);
+        introMap.set("Other household income, such as income from property between [DATE_A_PY_1] and [DATE_B_PY_1]",3);
+        introMap.set("Your income and benefits between [DATE_A] and [DATE_B]",4);
+        introMap.set("Your partner’s income and benefits between [DATE_A] and [DATE_B]",5);
+        introMap.set("Other household income, such as income from property between [DATE_A] and [DATE_B]",6);
         introMap.set("Report any changes to circumstances",7);
 
         updateHeaders(posY, headerData, introMap);
     }
 
     function updateHeaders(posY, headerData, introMap) {
-
         function replaceXCounter(group, xvalue) {
             data().questions.forEach(function (question) {
-                if (question.group !== undefined && question.group == group) {
+                if (isDefined(question.group) && question.group === group) {
                     question.question = question.question.replace("[REPLACE_X]", xvalue);
                 }
             });
         }
 
-        // Override template values in questions.
+        // Update REPLACE_Y with part number.
         data().questions.forEach(function (question) {
-            question.question = replaceStringKeysWithValues(question.question, posY);
+            question.question = question.question.replace("[REPLACE_Y]", posY);
         });
 
         // Update REPLACE_X header with question Part numbers from headerData groups.
@@ -103,7 +102,7 @@
         totalMessages.innerHTML = ''; // clear existing
         totalMessages.appendChild(document.createTextNode(''+posY));
 
-        //Add a warning for D2 renewals
+        //Add a warning to the intro for D2 renewals
         if(getRenewalType() === JOINT_D2 || getRenewalType() === SINGLE_D2){
             var warning = document.getElementById("completingReviewWarningForD2");
             warning.style.display = "block";
@@ -121,21 +120,9 @@
                             "</li><br/>"
             insertDynamicPoint.appendChild(cln);
         });
-    }
 
-    function replaceStringKeysWithValues(inString, posY) {
-        // Update the question headers with position info and dates.
-        var endDate = map.get("endDate");
-        var startDate = map.get("startDate");
-        var endDate_PY_1 = map.get("endDate_PY_1");
-        var startDate_PY_1 = map.get("startDate_PY_1");
-
-        var update = inString.replace("[REPLACE_Y]", posY);
-        update = update.replace("[DATE_A]", startDate);
-        update = update.replace("[DATE_B]", endDate);
-        update = update.replace("[DATE_A_PY_1]", startDate_PY_1);
-        update = update.replace("[DATE_B_PY_1]", endDate_PY_1);
-        return(update);
+        //Replace all common variables in intro element.
+        replaceCommonVariablesInElement(insertDynamicPoint);
     }
 
 </script>

--- a/app/views/tags/jsQuestionHeaders.scala.html
+++ b/app/views/tags/jsQuestionHeaders.scala.html
@@ -103,6 +103,12 @@
         totalMessages.innerHTML = ''; // clear existing
         totalMessages.appendChild(document.createTextNode(''+posY));
 
+        //Add a warning for D2 renewals
+        if(getRenewalType() === JOINT_D2 || getRenewalType() === SINGLE_D2){
+            var warning = document.getElementById("completingReviewWarningForD2");
+            warning.style.display = "block";
+        }
+
         var itm = document.getElementById("cloneForInsertPoint");
         var insertDynamicPoint = document.getElementById("dynamicInsertPoint");
         insertDynamicPoint.innerHTML = '';

--- a/app/views/tags/jsTCRQuestions.scala.html
+++ b/app/views/tags/jsTCRQuestions.scala.html
@@ -461,7 +461,7 @@
                 "section":"OTHER-INCOME",
                 "questionType": {
                 "type": "MultipleChoiceWithNumber",
-                    "questionFooterDiv": "which-of-these-benefits-did-you-get-at-the-time",
+                    "questionFooterDiv": "let-us-know-how-much-you-have-earned",
                     "multipleChoiceOptions": [
                     {
                         "option": "Savings, investments and dividends",
@@ -673,6 +673,7 @@
                 "question": "<span class='pre-header'>Part [REPLACE_X] of [REPLACE_Y]: Your benefits and income</span>How much did you earn from all of your jobs as an employee between [DATE_A] and [DATE_B]?",
                 "questionType": {
                   "type": "Decimal",
+                  "questionFooterDiv": "let-us-know-how-much-you-have-earned",
                   "nextQuestionId": "Did you get any company benefits",
                   "modelId": "incomeDetails.earnings"
                 }

--- a/app/views/tax_credit_renewal_app.scala.html
+++ b/app/views/tax_credit_renewal_app.scala.html
@@ -538,6 +538,9 @@
                 If you sign out, your changes will be saved for 28 days. After that time you will need to start from the beginning.
             </p>
 
+            <p id="completingReviewWarningForD2" style="display: none">As you were not able to provide us with actual income figures when applying for tax credits,
+                we will need to ask you questions about the previous 2 tax years.</p>
+
             <p>This review is divided into <span id="completing-review-message-total">3</span> parts.</p>
             <ul class="list-bullet">
 

--- a/app/views/tax_credit_renewal_app.scala.html
+++ b/app/views/tax_credit_renewal_app.scala.html
@@ -612,12 +612,12 @@
                 If you have not already told us that you no longer receive this benefit, you should report this as a change in this review.
             </div>
         </div>
-        <div id="which-of-these-benefits-did-you-get-at-the-time">
+        <div id="let-us-know-how-much-you-have-earned">
             <p>Let us know how much you earned before anything was taken off. Use the ‘total pay’ or ‘total for year’ amount on your P60.</p>
             <details>
                 <summary>What if I do not have my P60?</summary>
                 <div class="panel">
-                    <p>If your employer has told us about your earned income between {award start date} and {award end date}, it is shown in step B of your renewal pack.
+                    <p>If your employer has told us about your earned income between [DATE_A] and [DATE_B], it is shown in step B of your renewal pack.
                     </p>
                     <div>
                         <svg viewbox="0 0 283.28 218.35"><use xlink:href="#p60"></use></svg>


### PR DESCRIPTION
I added the expandable copy which was missing on the employed income page as a questionFooterDiv.  The copy contained some variables for start period/end period. We were already processing dynamic variables in a couple of places so instead of adding another in the insertDynamicHeader function I moved the functionality to the displayQuestion() and removed it from the other places.  This means the entire question page including dynamic/static content is processed in a single hit before rendering.