### PR TITLE
Added a clear on the currency input field to fix floating pound sign

### DIFF
--- a/app/assets/styles/scss/_base.scss
+++ b/app/assets/styles/scss/_base.scss
@@ -537,6 +537,7 @@ h1.hidden {
 //Currency input, input with pound sign
 .currency-input {
   position: relative;
+  clear: both;
   .pound-icon {
     position: absolute;
     left: 5px;

--- a/app/views/tags/styles_android.scala.html
+++ b/app/views/tags/styles_android.scala.html
@@ -445,7 +445,8 @@ h1.hidden {
   display: none; }
 
 .currency-input {
-  position: relative; }
+  position: relative;
+  clear: both; }
   .currency-input .pound-icon {
     position: absolute;
     left: 5px;

--- a/app/views/tags/styles_ios.scala.html
+++ b/app/views/tags/styles_ios.scala.html
@@ -445,7 +445,8 @@ h1.hidden {
   display: none; }
 
 .currency-input {
-  position: relative; }
+  position: relative;
+  clear: both; }
   .currency-input .pound-icon {
     position: absolute;
     left: 5px;

--- a/app/views/tags/styles_win.scala.html
+++ b/app/views/tags/styles_win.scala.html
@@ -445,7 +445,8 @@ h1.hidden {
   display: none; }
 
 .currency-input {
-  position: relative; }
+  position: relative;
+  clear: both; }
   .currency-input .pound-icon {
     position: absolute;
     left: 5px;


### PR DESCRIPTION
# Problem
The new container that contains the input with the pound symbol needs clearing as the pound sign is positioned incorrectly when not cleared.
![screen shot 2017-04-24 at 09 18 43](https://cloud.githubusercontent.com/assets/10154302/25328290/3b237c9e-28cf-11e7-9149-1b351f06f61c.png)

# Solution
Add a simple clear both on the div then the pound sign positions correctly
![screen shot 2017-04-24 at 09 18 57](https://cloud.githubusercontent.com/assets/10154302/25328321/54c3d5cc-28cf-11e7-97f7-da6c9b5dfc5e.png)

