### PR TITLE
Removed the rule that was removing borders from inputs with a type at…

### DIFF
--- a/app/assets/styles/scss/android.scss
+++ b/app/assets/styles/scss/android.scss
@@ -59,11 +59,6 @@ main input[type="button"].primary {
 			opacity: 1;
 		}
 	}
-
-	input[type="number"] {
-		border: none;
-		border-bottom: 1px solid;
-	}
 }
 
 

--- a/app/views/tags/styles_android.scala.html
+++ b/app/views/tags/styles_android.scala.html
@@ -490,9 +490,5 @@ main input[type="button"].primary {
   left: 5px;
   opacity: 1; }
 
-#MultipleChoice input[type="number"] {
-  border: none;
-  border-bottom: 1px solid; }
-
 .edit-income-btn__icon .android {
   display: table-cell; }


### PR DESCRIPTION
# Problem
All input fields that have a type attribute with a value of number were missing border styles(Android only)

# Solution
Removed the overriding rule that was removing the border style